### PR TITLE
Making nintendoId mandatory on Objects. Not returning self on teammat…

### DIFF
--- a/src/main/java/com/kjam/graphQL/configurations/ScalarConfiguration.java
+++ b/src/main/java/com/kjam/graphQL/configurations/ScalarConfiguration.java
@@ -12,7 +12,6 @@ import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.language.StringValue;
-import graphql.scalars.ExtendedScalars;
 import graphql.schema.GraphQLScalarType;
 
 @Configuration
@@ -20,11 +19,6 @@ public class ScalarConfiguration {
 
     private final static String NINTENDO_ID_REGEX = "(nin)[0-9]{4}";
     
-    @Bean
-    public GraphQLScalarType dateTime() {
-        return ExtendedScalars.DateTime;
-    }
-
     @Bean
     public GraphQLScalarType nintendoId() {
         return GraphQLScalarType.newScalar()

--- a/src/main/java/com/kjam/graphQL/repositories/TeamRepository.java
+++ b/src/main/java/com/kjam/graphQL/repositories/TeamRepository.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface TeamRepository extends ReactiveCrudRepository<Teammate, String>{
-    @Query("SELECT TEAM_ID, NINTENDO_ID, TEAM_NM, MANAGER_ID FROM NINTENDO.TEAM WHERE TEAM_ID IN (SELECT TEAM_ID FROM NINTENDO.TEAM WHERE NINTENDO_ID = $1)")
+    @Query("SELECT TEAM_ID, NINTENDO_ID, TEAM_NM, MANAGER_ID FROM NINTENDO.TEAM WHERE TEAM_ID IN (SELECT TEAM_ID FROM NINTENDO.TEAM WHERE NINTENDO_ID = $1) AND NINTENDO_ID != $1")
     Flux<Teammate> findTeamByNintendoId(String nintendoId);
 
     @Query("SELECT TEAM_ID, NINTENDO_ID, TEAM_NM, MANAGER_ID FROM NINTENDO.TEAM WHERE TEAM_ID = $1")

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -1,9 +1,7 @@
-scalar DateTime
 scalar NintendoId
 
 type Query {
-    name(id: NintendoId): Name
+    name(id: NintendoId!): Name
     teammates(id: NintendoId!): [Teammate]
     team(teamId: String!): [Teammate]
 }
-

--- a/src/main/resources/graphql/team.graphqls
+++ b/src/main/resources/graphql/team.graphqls
@@ -1,13 +1,13 @@
 type Name {
-    nintendoId: String
+    nintendoId: String!
     firstName: String
     middleName: String
     lastName: String
 }
 
 type Teammate {
-    nintendoId: String
-    teamId: String
+    nintendoId: String!
+    teamId: String!
     teamName: String
     managerId: String
     name: Name

--- a/src/test/java/com/kjam/graphQL/repositories/RepositoryTest.java
+++ b/src/test/java/com/kjam/graphQL/repositories/RepositoryTest.java
@@ -34,20 +34,26 @@ public class RepositoryTest {
 
     @Test
     public void retrieveTeammatesByNintendoId() {
-        var teamIterable = repository.findTeamByNintendoId("nin0001").toIterable();
+        var nintendoId = "nin0001";
+        var teamIterable = repository.findTeamByNintendoId(nintendoId).toIterable();
         var teammates = StreamSupport.stream(teamIterable.spliterator(), false).collect(Collectors.toList());
-        Assertions.assertEquals(4, teammates.size());
-        teammates.forEach(teammate -> Assertions.assertEquals("nintendo01", teammate.getTeamId()));
+        Assertions.assertEquals(3, teammates.size());
+        teammates.forEach(teammate -> {
+            Assertions.assertEquals("nintendo01", teammate.getTeamId());
+            Assertions.assertNotEquals(nintendoId, teammate.getNintendoId());
+        });
     }
 
     @Test
     public void whenTeammateIsOnMultipleTeams_thenReturnMembersFromBothTeams() {
-        var teamIterable = repository.findTeamByNintendoId("nin9999").toIterable();
+        var nintendoId = "nin9999";
+        var teamIterable = repository.findTeamByNintendoId(nintendoId).toIterable();
         var teammates = StreamSupport.stream(teamIterable.spliterator(), false).collect(Collectors.toList());
-        Assertions.assertEquals(8, teammates.size());
+        Assertions.assertEquals(6, teammates.size());
         teammates.forEach(teammate -> {
             var teamId = teammate.getTeamId();
             Assertions.assertTrue("nintendo01".equalsIgnoreCase(teamId) || "nintendo02".equalsIgnoreCase(teamId));
+            Assertions.assertNotEquals(nintendoId, teammate.getNintendoId());
         });
     }
 

--- a/src/test/resources/graphql/queries/responses/teammates.json
+++ b/src/test/resources/graphql/queries/responses/teammates.json
@@ -2,17 +2,6 @@
     "data": {
         "teammates": [
             {
-                "nintendoId": "nin0001",
-                "teamId": "nintendo01",
-                "teamName": "Super Mario",
-                "managerId": "nin9999",
-                "name": {
-                    "firstName": "Mario",
-                    "middleName": "Jumpman",
-                    "lastName": "Nintendo"
-                }
-            },
-            {
                 "nintendoId": "nin0002",
                 "teamId": "nintendo01",
                 "teamName": "Super Mario",


### PR DESCRIPTION
Making Nintendo ID mandatory on Type Objects in schema. 
Not returning self (nintendo id we query by) when retrieving teammates. 